### PR TITLE
Checking for sound file not found and returning proper string

### DIFF
--- a/src/main/java/soundchan/LocalAudioManager.java
+++ b/src/main/java/soundchan/LocalAudioManager.java
@@ -58,6 +58,9 @@ public class LocalAudioManager {
                 path = "";
             }
         }
+        if(path.contentEquals(filepath + "/null")) {
+            return "";
+        }
         return path;
     }
 


### PR DESCRIPTION
Getting rid of this:
```
Sound-Chan: Nothing found by /home/matt/Music/SoundChan/null
```
and having it say this instead:
```
Sound-Chan: File "SoundChan" not found!
```